### PR TITLE
Add retries to loginByGCP() method

### DIFF
--- a/src/main/java/com/datapipe/jenkins/vault/credentials/VaultGCPCredential.java
+++ b/src/main/java/com/datapipe/jenkins/vault/credentials/VaultGCPCredential.java
@@ -47,7 +47,7 @@ public class VaultGCPCredential extends AbstractVaultTokenCredential {
         }
 
         try {
-            return vault.auth().loginByGCP(role, jwt).getAuthClientToken();
+            return vault.withRetries(5, 500).auth().loginByGCP(role, jwt).getAuthClientToken();
         } catch (VaultException e) {
             throw new VaultPluginException("could not log in into vault", e);
         }


### PR DESCRIPTION
This will make logging in by GCP more robust, making the plugin
to retry 5 times with interval of 500 miliseconds, before actually
failing.

Signed-off-by: Karol Krawczyk <kkrawczyk@griddynamics.com>